### PR TITLE
Implement `deleteSerieById` functionality

### DIFF
--- a/src/graphql/context/prismaMutations/index.ts
+++ b/src/graphql/context/prismaMutations/index.ts
@@ -98,12 +98,30 @@ async function deleteCharacterById(id: string) {
   }
 }
 
+async function deleteSerieById(id: string) {
+  try {
+    const deletedSerie = await prisma.serie.delete({
+      where: {
+        id,
+      },
+      include: {
+        characters: true,
+      },
+    });
+
+    return deletedSerie;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 export const mutations = Object.freeze({
   createSerie,
   createCharacter,
   updateSerieById,
   updateCharacterById,
   deleteCharacterById,
+  deleteSerieById,
 });
 
 export type MutationsType = typeof mutations;

--- a/src/graphql/resolvers/index.ts
+++ b/src/graphql/resolvers/index.ts
@@ -59,5 +59,11 @@ export const resolvers = {
       args: { id: string },
       context: Context,
     ) => await context.mutations.deleteCharacterById(args.id),
+
+    deleteSerieById: async (
+      _parent: any,
+      args: { id: string },
+      context: Context,
+    ) => await context.mutations.deleteSerieById(args.id),
   },
 };

--- a/src/graphql/schema/index.ts
+++ b/src/graphql/schema/index.ts
@@ -87,6 +87,8 @@ export const typeDefs = gql`
       serieId: ID
     ): Character
 
+    deleteSerieById(id: ID!): Serie
+
     deleteCharacterById(id: ID!): Character
   }
 `;


### PR DESCRIPTION
## This PR implements the issue #14.

### Done:
- created `deleteSerieById` mutation type in schema.
- created `deleteSerieById` resolver function.
- created `prisma query` to delete serie by id.

**OBS:** This method delete all the `characters` related to the serie

Closes #14 