### PR TITLE
Create modal component to list series in small devices

### DIFF
--- a/src/app/@modal/(.)series-list/page.tsx
+++ b/src/app/@modal/(.)series-list/page.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+
+import Modal from '@/components/Modal';
+import { createSerieDatasource } from '@/data/serie';
+
+export default async function SeriesListModal() {
+  const seriesDatasource = createSerieDatasource();
+  const { returnedSeries: series } = await seriesDatasource.getAll();
+
+  return (
+    <Modal>
+      <div className="relative flex w-64 max-w-md flex-col space-y-3 rounded-md bg-slate-50 px-4 py-2 text-center">
+        <Link href="/" className="absolute right-4 text-slate-800">
+          ❌{/* TODO - create `close button component ( use router.back() )` */}
+        </Link>
+
+        {series.map((serie) => (
+          <Link
+            key={serie.id}
+            href={{
+              pathname: '/',
+              query: { serieId: serie.id },
+            }}
+            className="text-slate-800 transition-colors hover:text-slate-900"
+          >
+            {serie.name}
+          </Link>
+        ))}
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/@modal/[...catchAll]/page.tsx
+++ b/src/app/@modal/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function CatchAll() {
+  return null;
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/default.tsx
+++ b/src/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,13 +12,16 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal,
 }: Readonly<{
   children: React.ReactNode;
+  modal: React.ReactNode;
 }>) {
   return (
     <html lang="en" className="h-screen">
       <body className={inter.className} style={{ height: '100vh' }}>
         {children}
+        {modal}
       </body>
     </html>
   );

--- a/src/app/series-list/page.tsx
+++ b/src/app/series-list/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function SeriesList() {
+  return redirect('/');
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,18 @@
+import { cn } from '@/lib/cn';
+
+type ModalProps = JSX.IntrinsicElements['dialog'];
+
+export default function Modal({ children, className, ...props }: ModalProps) {
+  return (
+    <dialog
+      open
+      className={cn(
+        'absolute top-0 flex h-screen w-screen items-center justify-center bg-[#333]/60',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </dialog>
+  );
+}

--- a/src/components/SeriesNavigation.tsx
+++ b/src/components/SeriesNavigation.tsx
@@ -16,22 +16,30 @@ export async function SeriesNavigation({ serieId }: SeriesNavigationProps) {
   }
 
   return (
-    <nav className="flex items-center justify-center pt-6">
-      {series.map((serie) => (
-        <Link
-          key={serie.id}
-          href={{
-            pathname: '/',
-            query: { serieId: serie.id },
-          }}
-          className={cn(
-            'animate-show-content-up px-4 py-2 text-slate-600 transition-colors hover:text-slate-800',
-            serieId === serie.id ? 'text-slate-900 underline' : '',
-          )}
-        >
-          <button>{serie.name}</button>
+    <>
+      <nav className="hidden items-center justify-center pt-6 md:flex">
+        {series.map((serie) => (
+          <Link
+            key={serie.id}
+            href={{
+              pathname: '/',
+              query: { serieId: serie.id },
+            }}
+            className={cn(
+              'animate-show-content-up px-4 py-2 text-slate-600 transition-colors hover:text-slate-800',
+              serieId === serie.id ? 'text-slate-900 underline' : '',
+            )}
+          >
+            <button>{serie.name}</button>
+          </Link>
+        ))}
+      </nav>
+
+      <div className="mt-2 flex w-full items-center justify-center md:hidden">
+        <Link href="/series-list" className="text-slate-800">
+          Show series
         </Link>
-      ))}
-    </nav>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
This PR implememts a `modal` functionality to list series in small devices.

It was implemented with [parallel routes](https://nextjs.org/docs/app/building-your-application/routing/parallel-routes) and [intercepting routes](https://nextjs.org/docs/app/building-your-application/routing/intercepting-routes)