### PR TITLE
Implement `list` visibility option in `characters list`

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { Suspense } from 'react';
 
 import CallToActions from '@/components/CallToActions';
@@ -6,21 +7,47 @@ import CharacterslistLoading from '@/components/CharacterslistLoading';
 import { Header } from '@/components/Header';
 import { SeriesNavigation } from '@/components/SeriesNavigation';
 import { Wrapper } from '@/components/Wrapper';
+import { cn } from '@/lib/cn';
 
 type HomeProps = {
   searchParams?: {
     serieId: string;
+    visibility?: 'card' | 'list';
   };
 };
 
 export default async function Home({ searchParams }: HomeProps) {
   const serieId = searchParams?.serieId;
+  const visibility = searchParams?.visibility ?? 'card';
 
   return (
     <div className="flex h-full flex-col overflow-y-hidden bg-slate-200">
       <Header />
       <Wrapper className="relative md:py-4">
         <SeriesNavigation serieId={serieId ?? ''} />
+
+        {serieId && (
+          <div className="mx-auto mb-2 w-fit space-x-2 rounded bg-slate-300 px-2">
+            <Link
+              href={`/?serieId=${serieId}&visibility=card`}
+              className={cn(
+                visibility === 'card' && 'bg-slate-100',
+                'rounded px-2 transition-colors hover:bg-slate-100',
+              )}
+            >
+              Card
+            </Link>
+            <Link
+              href={`/?serieId=${serieId}&visibility=list`}
+              className={cn(
+                visibility === 'list' && 'bg-slate-100',
+                'rounded px-2 transition-colors hover:bg-slate-100',
+              )}
+            >
+              List
+            </Link>
+          </div>
+        )}
         <main className="flex flex-1 flex-col items-center justify-center overflow-y-auto">
           {!serieId ? (
             <p className="text-center">
@@ -29,7 +56,7 @@ export default async function Home({ searchParams }: HomeProps) {
             </p>
           ) : (
             <Suspense fallback={<CharacterslistLoading />}>
-              <CharactersList serieId={serieId} />
+              <CharactersList serieId={serieId} visibility={visibility} />
             </Suspense>
           )}
         </main>

--- a/src/components/CharactersList.tsx
+++ b/src/components/CharactersList.tsx
@@ -1,13 +1,22 @@
+import Link from 'next/link';
+
 import { Card } from '@/components/Card';
 import { Tooltip } from '@/components/Tooltip';
 import { createCharacterDatasource } from '@/data/character';
 import { cn } from '@/lib/cn';
 
+import { EditIcon } from './icons/EditIcon';
+import { TrashIcon } from './icons/TrashIcon';
+
 type CharactersListProps = {
   serieId: string;
+  visibility?: 'card' | 'list';
 };
 
-export async function CharactersList({ serieId }: CharactersListProps) {
+export async function CharactersList({
+  serieId,
+  visibility = 'card',
+}: CharactersListProps) {
   const characterDatasource = createCharacterDatasource();
   const { returnedCharacters: characters } =
     await characterDatasource.getAllBySerieId(serieId);
@@ -24,6 +33,45 @@ export async function CharactersList({ serieId }: CharactersListProps) {
         </p>
       </div>
     );
+
+  if (visibility === 'list') {
+    return (
+      <div className="flex h-full w-full flex-col gap-1 px-16 py-2">
+        {characters.map((character) => (
+          <div
+            key={character.id}
+            className="relative flex w-full gap-4 rounded-md bg-slate-100 p-4"
+          >
+            <div className="flex flex-col">
+              <Tooltip
+                tip="see more"
+                aria-label={`see more about ${character.name}`}
+              >
+                <strong>
+                  <Link href={`/character/${character.id}`}>
+                    {character.name}
+                  </Link>
+                </strong>
+              </Tooltip>
+
+              <span>{character.nickName}</span>
+            </div>
+
+            <p>{character.serie.name}</p>
+
+            <div className="absolute right-2 flex gap-2">
+              <Link href={`/character/edit/${character.id}`}>
+                <EditIcon className="transition-transform hover:scale-105" />
+              </Link>
+              <Link href={`/character/delete/${character.id}`}>
+                <TrashIcon className="transition-transform hover:scale-105" />
+              </Link>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div


### PR DESCRIPTION
## This PR resolves the issue #47

## Done:
- implemented `visibility` searchParam
- `Links` to card or list visibility param

## Implementation
- If has no visibility in searchParam, it renders in `Card` visualization.
- If has visibility equals to `list` renders `List` visualization.

Resolve #47 