### PR TITLE
Passing `name` property as `query string` to delete confirmation modals

### DIFF
--- a/src/app/@modal/(.)character/delete/[id]/page.tsx
+++ b/src/app/@modal/(.)character/delete/[id]/page.tsx
@@ -27,14 +27,17 @@ type Props = {
   params: {
     id: string;
   };
+  searchParams: {
+    name: string;
+  };
 };
 
-export default async function Page({ params }: Props) {
+export default async function Page({ params, searchParams: { name } }: Props) {
   const { id } = params;
 
   return (
     <Modal>
-      <p>Are you sure you want to delete this character?</p>
+      <p>Are you sure you want to delete {name}?</p>
 
       <div>
         <form action={serverActionToDeleteCharacter} className="space-x-2">

--- a/src/app/@modal/(.)serie/delete/[id]/page.tsx
+++ b/src/app/@modal/(.)serie/delete/[id]/page.tsx
@@ -41,14 +41,17 @@ type Params = {
   params: {
     id: string;
   };
+  searchParams: {
+    name: string;
+  };
 };
 
-export default function Page({ params }: Params) {
+export default function Page({ params, searchParams: { name } }: Params) {
   return (
     <Modal>
-      <p>Are you sure you want to delete this serie?</p>
+      <p>Are you sure you want to delete this serie: {name}?</p>
       <strong className="mt-2 text-xs">
-        This action will delete all characters related to this serie
+        This action will delete all characters related to {name}
       </strong>
       <form action={serverActionToDeleteSerie} className="space-x-2">
         <NavigateBack className="rounded bg-red-400 px-2 text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed">

--- a/src/app/serie/[serieId]/page.tsx
+++ b/src/app/serie/[serieId]/page.tsx
@@ -31,7 +31,14 @@ export default async function Page({ params }: Params) {
         <Link href={`/serie/edit/${params.serieId}`}>
           <EditIcon className="transition-transform hover:scale-105" />
         </Link>
-        <Link href={`/serie/delete/${params.serieId}`}>
+        <Link
+          href={{
+            pathname: `/serie/delete/${params.serieId}`,
+            query: {
+              name: returnedSerie.name,
+            },
+          }}
+        >
           <TrashIcon className="transition-transform hover:scale-105" />
         </Link>
       </div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -33,7 +33,10 @@ export function Card({ character }: CardProps) {
             </Link>
             <p className="text-gray-300">{character.nickName || '-'}</p>
             <Link
-              href={`/character/delete/${character.id}`}
+              href={{
+                pathname: `/character/delete/${character.id}`,
+                query: { name: character.name },
+              }}
               className="transition-all hover:scale-110"
             >
               <TrashIcon />


### PR DESCRIPTION
Passing `name` property as `query string` to Link components.

Now the delete confirmation modals can show the serie or character name by recovering it from url searchParams.
